### PR TITLE
fix: change deprecated pillow 'antialiasing' to 'lanczos'

### DIFF
--- a/EdgeWare/popup.pyw
+++ b/EdgeWare/popup.pyw
@@ -287,7 +287,7 @@ def run():
         size_source = max(img.width, img.height) / min(screen_width, screen_height)
         size_target = rand.randint(30, 70) / 100 if not LOWKEY_MODE else rand.randint(20, 50) / 100
         resize_factor = size_target / size_source
-        return image.resize((int(image.width * resize_factor), int(image.height * resize_factor)), Image.ANTIALIAS)
+        return image.resize((int(image.width * resize_factor), int(image.height * resize_factor)), Image.LANCZOS)
 
     resized_image = resize(image)
 

--- a/EdgeWare/startup_flair.pyw
+++ b/EdgeWare/startup_flair.pyw
@@ -18,7 +18,7 @@ def doAnimation():
     
     img_ = Image.open(os.path.join(PATH, 'default_assets', 'loading_splash.png'))
     
-    img = ImageTk.PhotoImage(img_.resize((int(img_.width * scalar), int(img_.height * scalar)), resample=Image.ANTIALIAS))
+    img = ImageTk.PhotoImage(img_.resize((int(img_.width * scalar), int(img_.height * scalar)), resample=Image.LANCZOS))
     root.geometry('{}x{}+{}+{}'.format(img.width(), img.height(), int((root.winfo_screenwidth() - img.width()) / 2), int((root.winfo_screenheight() - img.height()) / 2)))
     lbl = Label(root, image=img)
     lbl.pack()

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Fork of Edgeware to add linux-compatability and more.
+https://github.com/Sassy0P/Edgeware/tree/linux-compability
 
 # Edgeware
 **First and foremost as a disclaimer: this is NOT actually malicious software. It is intended for entertainment purposes only. Any and all damage caused to your files or computer is _YOUR_ responsibility. If you're worried about losing things, BACK THEM UP.**


### PR DESCRIPTION
The Pillow's image filter 'antialiasing' has been deprecated for some time and is now removed in the new version Pillow 10.0, 
making the program crash.

Updating the value allow to resolve this problem.

Fixing: #47, #48 